### PR TITLE
Add React Native scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,9 @@ Game Page Screen
 Home Page Screen
 <img src="home_page.png" width="300" height="500"> |
 
+
+## React Native Version (WIP)
+
+A scaffolded React Native app is available in the `react-native-app` directory. It uses Expo and Firebase to demonstrate authentication, Firestore integration, and a simple game loop fetching questions from the OpenTDB API.
+
+Run `npm install` in that folder and then `npm start` to launch the development server.

--- a/react-native-app/App.tsx
+++ b/react-native-app/App.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import AppNavigator from './src/navigation/AppNavigator';
+
+export default function App() {
+  return <AppNavigator />;
+}

--- a/react-native-app/README.md
+++ b/react-native-app/README.md
@@ -1,0 +1,23 @@
+# React Native Trivia App
+
+This is a scaffold for a React Native trivia game powered by Firebase and the OpenTDB API. It focuses on authentication, Firestore setup, and a basic game loop. The project uses Expo for quick setup.
+
+## Getting Started
+
+1. Install dependencies
+
+```bash
+npm install
+```
+
+2. Set your Firebase credentials in `src/firebaseConfig.ts`.
+
+3. Run the development server
+
+```bash
+npm start
+```
+
+The basic game pulls questions from OpenTDB and tracks the score locally. Authentication is handled via Firebase Auth. User profiles are created in Firestore on sign up.
+
+This skeleton provides a foundation to expand with features like multiplayer, in-app purchases, ads, and leaderboards.

--- a/react-native-app/package.json
+++ b/react-native-app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "trivia-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^53.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.0",
+    "firebase": "^10.0.0",
+    "@react-navigation/native": "^6.1.9",
+    "@react-navigation/native-stack": "^6.9.18"
+  }
+}

--- a/react-native-app/src/firebaseConfig.ts
+++ b/react-native-app/src/firebaseConfig.ts
@@ -1,0 +1,16 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_FIREBASE_API_KEY',
+  authDomain: 'YOUR_FIREBASE_AUTH_DOMAIN',
+  projectId: 'YOUR_FIREBASE_PROJECT_ID',
+  storageBucket: 'YOUR_FIREBASE_STORAGE_BUCKET',
+  messagingSenderId: 'YOUR_FIREBASE_MESSAGING_SENDER_ID',
+  appId: 'YOUR_FIREBASE_APP_ID',
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getFirestore(app);

--- a/react-native-app/src/navigation/AppNavigator.tsx
+++ b/react-native-app/src/navigation/AppNavigator.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import LoginScreen from '../screens/LoginScreen';
+import HomeScreen from '../screens/HomeScreen';
+import GameScreen from '../screens/GameScreen';
+
+export type RootStackParamList = {
+  Login: undefined;
+  Home: undefined;
+  Game: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function AppNavigator() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Game" component={GameScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/react-native-app/src/screens/GameScreen.tsx
+++ b/react-native-app/src/screens/GameScreen.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../navigation/AppNavigator';
+import { fetchQuestions, Question } from '../services/questionService';
+
+export default function GameScreen({ navigation }: NativeStackScreenProps<RootStackParamList, 'Game'>) {
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [current, setCurrent] = useState(0);
+  const [score, setScore] = useState(0);
+
+  useEffect(() => {
+    (async () => {
+      const data = await fetchQuestions(10);
+      setQuestions(data);
+    })();
+  }, []);
+
+  const handleAnswer = (answer: string) => {
+    if (answer === questions[current].correct_answer) {
+      setScore(score + 1);
+    }
+    if (current + 1 < questions.length) {
+      setCurrent(current + 1);
+    } else {
+      navigation.navigate('Home');
+    }
+  };
+
+  if (!questions.length) {
+    return <View />;
+  }
+
+  const q = questions[current];
+  const choices = [...q.incorrect_answers, q.correct_answer].sort();
+
+  return (
+    <View style={{ flex: 1, padding: 16, justifyContent: 'center' }}>
+      <Text>{q.question}</Text>
+      {choices.map(choice => (
+        <Button key={choice} title={choice} onPress={() => handleAnswer(choice)} />
+      ))}
+      <Text>Score: {score}</Text>
+    </View>
+  );
+}

--- a/react-native-app/src/screens/HomeScreen.tsx
+++ b/react-native-app/src/screens/HomeScreen.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { View, Button, Text } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../navigation/AppNavigator';
+
+export default function HomeScreen({ navigation }: NativeStackScreenProps<RootStackParamList, 'Home'>) {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text style={{ fontSize: 24, marginBottom: 20 }}>Welcome to Trivia!</Text>
+      <Button title="Start Game" onPress={() => navigation.navigate('Game')} />
+    </View>
+  );
+}

--- a/react-native-app/src/screens/LoginScreen.tsx
+++ b/react-native-app/src/screens/LoginScreen.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button } from 'react-native';
+import { signIn, signUp } from '../services/auth';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../navigation/AppNavigator';
+import { createUserProfile } from '../services/userService';
+
+export default function LoginScreen({ navigation }: NativeStackScreenProps<RootStackParamList, 'Login'>) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSignUp = async () => {
+    const cred = await signUp(email, password);
+    await createUserProfile({ uid: cred.user.uid, email, xp: 0, coins: 0 });
+    navigation.replace('Home');
+  };
+
+  const handleSignIn = async () => {
+    await signIn(email, password);
+    navigation.replace('Home');
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 16 }}>
+      <TextInput placeholder="Email" onChangeText={setEmail} value={email} style={{ marginBottom: 12 }} />
+      <TextInput placeholder="Password" secureTextEntry onChangeText={setPassword} value={password} style={{ marginBottom: 12 }} />
+      <Button title="Sign In" onPress={handleSignIn} />
+      <Button title="Sign Up" onPress={handleSignUp} />
+    </View>
+  );
+}

--- a/react-native-app/src/services/auth.ts
+++ b/react-native-app/src/services/auth.ts
@@ -1,0 +1,10 @@
+import { createUserWithEmailAndPassword, signInWithEmailAndPassword } from 'firebase/auth';
+import { auth } from '../firebaseConfig';
+
+export const signUp = (email: string, password: string) => {
+  return createUserWithEmailAndPassword(auth, email, password);
+};
+
+export const signIn = (email: string, password: string) => {
+  return signInWithEmailAndPassword(auth, email, password);
+};

--- a/react-native-app/src/services/questionService.ts
+++ b/react-native-app/src/services/questionService.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+export interface Question {
+  category: string;
+  type: string;
+  difficulty: string;
+  question: string;
+  correct_answer: string;
+  incorrect_answers: string[];
+}
+
+export const fetchQuestions = async (amount = 10, category?: number, difficulty?: string) => {
+  const params = new URLSearchParams({ amount: amount.toString() });
+  if (category) params.append('category', category.toString());
+  if (difficulty) params.append('difficulty', difficulty);
+  const response = await axios.get(`https://opentdb.com/api.php?${params.toString()}`);
+  return response.data.results as Question[];
+};

--- a/react-native-app/src/services/userService.ts
+++ b/react-native-app/src/services/userService.ts
@@ -1,0 +1,13 @@
+import { doc, setDoc } from 'firebase/firestore';
+import { db } from '../firebaseConfig';
+
+export interface UserProfile {
+  uid: string;
+  email: string;
+  xp: number;
+  coins: number;
+}
+
+export const createUserProfile = async (profile: UserProfile) => {
+  await setDoc(doc(db, 'users', profile.uid), profile);
+};

--- a/react-native-app/tsconfig.json
+++ b/react-native-app/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "jsx": "react",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a React Native scaffold app under `react-native-app`
- wire up Firebase config and simple auth helpers
- add navigation and basic screens
- integrate question fetching from OpenTDB
- update root README with reference to the RN version

## Testing
- `npm test --silent` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_6870509c0a48832eaa4b975e17a9e479